### PR TITLE
Fix zone name issue

### DIFF
--- a/src/components/shared/Result/Result.js
+++ b/src/components/shared/Result/Result.js
@@ -42,14 +42,17 @@ const Result = () => {
       {stations.map(({ id, stationName, railZone }) => (
         <p key={id}>
           {stationName} is{' '}
-          {railZone ? (
+          {railZone < 6 && (
             <>
               in <strong>Zone {railZone}</strong>
             </>
-          ) : (
-            <strong>Out of County</strong>
           )}
-          .
+          {railZone === 6 && (
+            <>
+              in <strong>nTrain Zone 5</strong>
+            </>
+          )}
+          {railZone === 7 && <strong>Out of County</strong>}.
         </p>
       ))}
       {fullAccessStations.length > 0 && (


### PR DESCRIPTION
Fix issue where zone names were showing incorrectly:
- Zones previously showing "Zone 7" now show as **Out of county**
- Zones previously showing "Zone 6" now show as **nTrain Zone 5**